### PR TITLE
ensure deadmuddy reference is valid before calling Kill function

### DIFF
--- a/Basic_Patch/python/hollywood/hollywood.py
+++ b/Basic_Patch/python/hollywood/hollywood.py
@@ -183,7 +183,7 @@ def luckyState():
         if (G.Patch_Plus == 1):
             skelter.ScriptUnhide()
     deadmuddy = Find("dead_muddy")
-    if (G.Muddy_Dead == 1):
+    if (G.Muddy_Dead == 1 and deadmuddy is not None):
         deadmuddy.Kill()
         G.Muddy_Dead = 2
     if(G.Killer_Key == 1):


### PR DESCRIPTION
Hi,

I had this bug recently, during the quest "Snuff is enough", after the anonymous phone call, player is supposed to go to the Luckee Star Motel and go to the room 2. But the door of the room 2 wasn't openable. I tried to run the `luckyState()` function from the console and the following error occurs :
``` py
Traceback (most recent call last):
File "", line 1, in ?
File "C:/Program Files (x86)/GOG Galaxy/Games/VtMB/Unofficial_Patch/python/hollywood\hollywood.py", line 187, in luckyState
deadmuddy.Kill()
AttributeError: 'None' object has no attribute 'Kill'
```
the value of the concerned variable where the following:
```
G.Story_State : 35
G.Muddy_Dead : 1
G.Lucky_Blood: 1
G.Lucky_Wolf : 0
```

This pull request is a suggestion to have a safe script so even if deadmuddy is equal to None, the rest of the script is executed and the quest linked to the Luckee Star are not stucked.